### PR TITLE
fix: Stronghold EntryDoor GRATES

### DIFF
--- a/mappings/b1.7.3#b1.8-pre1-091358.tinydiff
+++ b/mappings/b1.7.3#b1.8-pre1-091358.tinydiff
@@ -3207,7 +3207,7 @@ c	net/minecraft/unmapped/C_55815768$C_41420377		StrongholdPiece
 c	net/minecraft/unmapped/C_55815768$C_41420377$C_62278610		EntranceType
 	f	Lnet/minecraft/unmapped/C_55815768$C_41420377$C_62278610;	f_67289399		OPENING
 	f	Lnet/minecraft/unmapped/C_55815768$C_41420377$C_62278610;	f_99153425		WOOD_DOOR
-	f	Lnet/minecraft/unmapped/C_55815768$C_41420377$C_62278610;	f_36120856		GATES
+	f	Lnet/minecraft/unmapped/C_55815768$C_41420377$C_62278610;	f_36120856		GRATES
 	f	Lnet/minecraft/unmapped/C_55815768$C_41420377$C_62278610;	f_02570352		IRON_DOOR
 	f	[Lnet/minecraft/unmapped/C_55815768$C_41420377$C_62278610;	f_29560944		f_29560944
 	m	()[Lnet/minecraft/unmapped/C_55815768$C_41420377$C_62278610;	values		values


### PR DESCRIPTION
nit, the enum name matters for `StrongholdPiece` serialization:

```java
	abstract static class StrongholdPiece extends StructurePiece {
		// ...
		@Override
		protected void writeNbt(NbtCompound nbt) {
			nbt.putString("EntryDoor", this.entranceType.name());
		}
		// ...
		public static enum EntranceType {
			OPENING,
			WOOD_DOOR,
			GATES,
			IRON_DOOR;
		}
```

`Stronghold.dat`:
```snbt
{
  data: {
    Features: {
      "[289,39]": {
        BB: [I;4529,8,574,4696,38,707],
        ChunkZ: 39,
        id: "Stronghold",
        Children: [
          {
            BB: [I;4626,28,626,4630,38,630],
            EntryDoor: "OPENING",
            id: "SHStart",
            GD: 0,
            Source: 1b,
            O: 3
          },
          {
            BB: [I;4631,26,623,4641,34,632],
            leftLow: 1b,
            EntryDoor: "IRON_DOOR",
            id: "SH5C",
            GD: 1,
            rightHigh: 0b,
            leftHigh: 1b,
            rightLow: 0b,
            O: 3
          },
          {
            BB: [I;4642,26,627,4648,30,631],
            Left: 0b,
            EntryDoor: "GRATES",
            Right: 0b,
            id: "SHS",
            GD: 2,
            O: 3
          },
...
```